### PR TITLE
GKE: Add support for specifying instance tags for Node Pools

### DIFF
--- a/google/_modules/gke/node_pool/main.tf
+++ b/google/_modules/gke/node_pool/main.tf
@@ -41,7 +41,7 @@ resource "google_container_node_pool" "current" {
 
     labels = var.metadata_labels
 
-    tags = var.metadata_tags
+    tags = concat(var.metadata_tags, var.instance_tags)
 
     workload_metadata_config {
       mode = var.node_workload_metadata_config

--- a/google/_modules/gke/node_pool/variables.tf
+++ b/google/_modules/gke/node_pool/variables.tf
@@ -119,6 +119,12 @@ variable "taints" {
   default     = null
 }
 
+variable "instance_tags" {
+  type = list(string)
+  description = "List of instance tags to apply to nodes."
+  default = []
+}
+
 variable "node_locations" {
   type        = list(string)
   description = "List of zones in the cluster's region to start worker nodes in. Defaults to cluster's node locations."

--- a/google/cluster/node-pool/configuration.tf
+++ b/google/cluster/node-pool/configuration.tf
@@ -39,4 +39,6 @@ locals {
   service_account_email = local.cfg["service_account_email"]
 
   network_config = local.cfg["network_config"]
+
+  instance_tags = local.cfg["instance_tags"]
 }

--- a/google/cluster/node-pool/main.tf
+++ b/google/cluster/node-pool/main.tf
@@ -30,7 +30,8 @@ module "node_pool" {
 
   node_workload_metadata_config = local.node_workload_metadata_config
 
-  taints = local.taints
+  taints        = local.taints
+  instance_tags = local.instance_tags
 
   service_account_email                 = local.service_account_email
   disable_per_node_pool_service_account = local.service_account_email == null ? false : true

--- a/google/cluster/node-pool/variables.tf
+++ b/google/cluster/node-pool/variables.tf
@@ -38,6 +38,8 @@ variable "configuration" {
       create_pod_range     = bool
       pod_ipv4_cidr_block  = string
     }))
+
+    instance_tags = optional(list(string))
   }))
   description = "Map with per workspace cluster configuration."
 }


### PR DESCRIPTION
Allow specifying of additional instance tags to Node Pools. This allows Firewall Rules to be attached to the nodes within the Node Pool.